### PR TITLE
APP_KEY generated to solve server error issues of deplyed App on Heroku

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -39,7 +39,7 @@ return [
     |
     */
 
-    'debug' => (bool) env('APP_DEBUG', false),
+    'debug' => (bool) env('APP_DEBUG', true),
 
     /*
     |--------------------------------------------------------------------------
@@ -119,7 +119,7 @@ return [
     |
     */
 
-    'key' => env('APP_KEY'),
+    'key' => env('APP_KEY', 'base64:Yt0WqK45KoinTL/EzDU1eiUrY4WrN7oTW66gWAmGN48='),
 
     'cipher' => 'AES-256-CBC',
 


### PR DESCRIPTION
## Description
some how Heroku wasnt able to generate APP_KEY automatically. I had to generate and add it manually.

Fixes #16 

## How Has This Been Tested?
 I did a direct deploy of changes to heroku and it did solved this issue.
